### PR TITLE
Add method cite_me() to print a list of publications used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
                  'Programming Language :: Python :: 3'],
     packages = ['trios', 'trios.feature_extractors', 'trios.classifiers', 'trios.legacy', 
                 'trios.window_determination', 'trios.shortcuts', 'trios.contrib', 'trios.contrib.kern_approx',
-                'trios.contrib.nilc'
+                'trios.contrib.nilc', 'trios.contrib.features',
                 ],
     install_requires=[
         'cython', 'cffi', 'numpy', 'scikit-learn', 'scipy', 'pillow', 'numba'

--- a/test/aperture_test.py
+++ b/test/aperture_test.py
@@ -27,3 +27,4 @@ if __name__ == '__main__':
     out = op.apply(img, img)
     p.save_image(out, 'out-ap-einstein.png')
     
+    print(op2.cite_me())

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -27,4 +27,6 @@ if __name__ == '__main__':
     p.save_image(out, 'out-dt-jung-1a.png')
     
     test = trios.Imageset.read('images/test.set')
-    print('Accuracy', op.eval(test, procs=7))
+    print('Accuracy', op.eval(test, procs=1))
+    
+    print(op2.cite_me())

--- a/test/isi_test.py
+++ b/test/isi_test.py
@@ -27,3 +27,5 @@ if __name__ == '__main__':
     
     test = trios.Imageset.read('images/test.set')
     print('Accuracy', op.eval(test, procs=7))
+    
+    print(op2.cite_me())

--- a/test/lbp_test.py
+++ b/test/lbp_test.py
@@ -18,3 +18,5 @@ if __name__ == '__main__':
 
     test = trios.Imageset.read('images/test.set')
     print('Accuracy', op.eval(test, procs=7))
+
+    print(op.cite_me())

--- a/test/two_level_test.py
+++ b/test/two_level_test.py
@@ -39,3 +39,5 @@ if __name__ == '__main__':
     p.save_image(out, 'out-isi-jung-1a.png')
     
     print('Accuracy', wop2.eval(test, procs=1))
+
+    print(wop2.cite_me())

--- a/trios/classifiers/base_classifier.pyx
+++ b/trios/classifiers/base_classifier.pyx
@@ -8,6 +8,9 @@ cdef class Classifier(Serializable):
     '''
     Classifies patterns extracted from the images. This is an abstract class.
     '''
+    
+    bibtex_citation = ''
+    
     def __init__(self, *a, **kw):
         r'''
         Classifiers have two basic attributes: minimize and ordered.
@@ -53,3 +56,4 @@ cdef class Classifier(Serializable):
         for i in range(fmatrix.shape[0]):
             y[i] = self.apply(fmatrix[i])
         return y
+    

--- a/trios/classifiers/isi.py
+++ b/trios/classifiers/isi.py
@@ -17,6 +17,17 @@ class ISI(Classifier):
     description here
     '''
     
+    bibtex_citation = '''
+@inproceedings{hirata2007basis,
+  title={Basis computation algorithms},
+  author={Hirata, Nina ST and Hirata Jr, Roberto and Barrera, Junior},
+  booktitle={Mathematical Morphhology and its Applications to Signal and Image Processing (Proceedings of the 8th International Symposium on Mathematical Morphology)},
+  pages={15--26},
+  year={2007}
+}
+
+    '''
+    
     def __init__(self, win=None):
         super(ISI, self).__init__()
         self.set_win(win)

--- a/trios/classifiers/linear.py
+++ b/trios/classifiers/linear.py
@@ -23,6 +23,9 @@ inside TRIOS.
 This class can be used, for example, to use the weights computed using Linear Regression
 models to do classification. 
     '''
+    
+    bibtex_citation = ''
+    
     def __init__(self, coefs=[], bias=0,  minimize=False):
         self.coefs = coefs
         self.bias = bias

--- a/trios/classifiers/sk_classifier.py
+++ b/trios/classifiers/sk_classifier.py
@@ -16,6 +16,22 @@ class SKClassifier(Classifier):
     '''
 This class wraps scikit-learn models. Any classification model should work.
     '''
+    
+    bibtex_citation = '''
+@article{scikit-learn,
+ title={Scikit-learn: Machine Learning in {P}ython},
+ author={Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V.
+         and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P.
+         and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and
+         Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E.},
+ journal={Journal of Machine Learning Research},
+ volume={12},
+ pages={2825--2830},
+ year={2011}
+}
+
+    '''
+    
     def __init__(self, cls=None, dtype=np.uint8, minimize=False, ordered=True, 
                  partial=False, **kw):
         super().__init__(self, **kw)

--- a/trios/contrib/kern_approx/nystrom.py
+++ b/trios/contrib/kern_approx/nystrom.py
@@ -1,3 +1,7 @@
+
+
+
+
 from trios.feature_extractors import RAWFeatureExtractor
 from trios.feature_extractors.base_extractor import FeatureExtractor
 from sklearn.metrics.pairwise import rbf_kernel
@@ -20,6 +24,17 @@ def fast_poly_kernel(X, Y, degree=3):
     return mat
 
 class NystromFeatures(FeatureExtractor):
+    bibtex_citation = '''
+@inproceedings{montagner2016kernel,
+  title={Kernel Approximations for W-operator learning},
+  author={Montagner, Igor S and Hirata, Roberto and Hirata, Nina ST and Canu, St{\'e}phane},
+  booktitle={Graphics, Patterns and Images (SIBGRAPI), 2016 29th SIBGRAPI Conference on},
+  pages={386--393},
+  year={2016},
+  organization={IEEE}
+}'''
+    
+    
     def __init__(self, fext=None, imageset=None, n_components=100, kernel='poly', degree=3, gamma=1, **kw):
         if fext is not None:
             super().__init__(fext.window, **kw)

--- a/trios/contrib/nilc/nilc.py
+++ b/trios/contrib/nilc/nilc.py
@@ -3,8 +3,7 @@ This module execute the NILC algorithm as proposed in *Montagner, I. S.,
 Hirata, N. S.T., Hirata Jr., R., ....*.
 '''
 
-bibtex_citation = '''
-@inproceedings{montagner2016nilc,
+bibtex_citation = '''@inproceedings{montagner2016nilc,
   title={NILC: a two level learning algorithm with operator selection},
   author={Montagner, Igor S and Hirata, Nina ST and Hirata, Roberto and Canu, St{\'e}phane},
   booktitle={Image Processing (ICIP), 2016 IEEE International Conference on},

--- a/trios/contrib/nilc/nilc.py
+++ b/trios/contrib/nilc/nilc.py
@@ -3,6 +3,16 @@ This module execute the NILC algorithm as proposed in *Montagner, I. S.,
 Hirata, N. S.T., Hirata Jr., R., ....*.
 '''
 
+bibtex_citation = '''
+@inproceedings{montagner2016nilc,
+  title={NILC: a two level learning algorithm with operator selection},
+  author={Montagner, Igor S and Hirata, Nina ST and Hirata, Roberto and Canu, St{\'e}phane},
+  booktitle={Image Processing (ICIP), 2016 IEEE International Conference on},
+  pages={1873--1877},
+  year={2016},
+  organization={IEEE}
+}'''
+
 import numpy as np
 from sklearn.linear_model import LogisticRegression, LogisticRegressionCV
 from trios.classifiers import LinearClassifier
@@ -132,6 +142,7 @@ def nilc_precomputed(Z, y, lamb=1, max_age=5):
     model_cv = LogisticRegressionCV(Cs=10, n_jobs=1, penalty='l1', solver='liblinear')
     model_cv.fit(Z[:, valstate.nonzeros], y)
     lin = LinearClassifier(model_cv.coef_.reshape(-1), model_cv.intercept_)
+    lin.bibtex_citation += bibtex_citation
     
     return valstate.operators, lin, progress_info
 
@@ -173,6 +184,7 @@ def nilc(training_set1, training_set2, operator_generator, domain, lamb=1, max_i
      
     second_level_pattern = CombinationPattern(*valstate.operators)    
     wop2 = WOperator(domain, lin, second_level_pattern)
+    wop2.bibtex_citation += bibtex_citation
     wop2.trained = True
     
     return wop2, progress_info

--- a/trios/feature_extractors/aperture.pyx
+++ b/trios/feature_extractors/aperture.pyx
@@ -10,6 +10,17 @@ cdef class Aperture(RAWFeatureExtractor):
     This feature extractor is based on the work on Aperture operators (or WK-operators, cite).
     It is used to introduce a
     '''
+    
+    bibtex_citation = '''
+@article{hirata2006aperture,
+  title={Aperture filters: theory, application, and multiresolution analysis},
+  author={Hirata Jr, Roberto and Brun, Marcel and Barrera, Junior and Dougherty, Edward R},
+  journal={Advances in Nonlinear Signal and Image Processing},
+  pages={15--45},
+  year={2006}
+}
+    '''
+    
     def __init__(self, window=None, k=1, center=None, mul=1.0, **kw):
         RAWFeatureExtractor.__init__(self, window, mul, **kw)
         self.k = k

--- a/trios/feature_extractors/base_extractor.pyx
+++ b/trios/feature_extractors/base_extractor.pyx
@@ -8,12 +8,18 @@ import scipy.ndimage
 
 from trios.wop_matrix_ops import process_image, process_image_ordered
 
+import sys
+
 cdef class FeatureExtractor(Serializable):
     '''
     A FeatureExtractor extracts feature from an Imageset using a finite neighborhood
     called *window*. The number and type of features extracted depend on the size of
     the window and on which processing each subclass of FeatureExtractor executes.
     '''
+    
+    bibtex_citation = '''
+'''
+    
     def __init__(self, unsigned char[:,:] window=None, batch_size=0, dtype=np.float):
         '''
         Every FeatureExtractor must receive a window (numpy array of type np.uint8) in
@@ -132,4 +138,4 @@ co-ocurred with the pattern. See the example below. ::
             self.batch_size = obj_dict['batch_size']
         else:
             self.batch_size = 0
-
+            

--- a/trios/feature_extractors/combination.pyx
+++ b/trios/feature_extractors/combination.pyx
@@ -60,6 +60,21 @@ cdef class CombinationPattern(FeatureExtractor):
     cdef public list fvectors
     cdef public int procs
 
+
+    bibtex_citation = '''
+@article{hirata2009multilevel,
+  title={Multilevel training of binary morphological operators},
+  author={Hirata, Nina ST},
+  journal={IEEE Transactions on pattern analysis and machine intelligence},
+  volume={31},
+  number={4},
+  pages={707--720},
+  year={2009},
+  publisher={IEEE}
+}
+
+    '''
+
     def __init__(self,  *wops, **kwargs):
         if len(wops) > 0:
             union = np.zeros_like(wops[0].window)

--- a/trios/feature_extractors/combination.pyx
+++ b/trios/feature_extractors/combination.pyx
@@ -61,19 +61,7 @@ cdef class CombinationPattern(FeatureExtractor):
     cdef public int procs
 
 
-    bibtex_citation = '''
-@article{hirata2009multilevel,
-  title={Multilevel training of binary morphological operators},
-  author={Hirata, Nina ST},
-  journal={IEEE Transactions on pattern analysis and machine intelligence},
-  volume={31},
-  number={4},
-  pages={707--720},
-  year={2009},
-  publisher={IEEE}
-}
-
-    '''
+    cdef public str bibtex_citation
 
     def __init__(self,  *wops, **kwargs):
         if len(wops) > 0:
@@ -98,6 +86,28 @@ cdef class CombinationPattern(FeatureExtractor):
 
         self.wops = list(wops)
         self.fvectors = None
+        self.fix_citations()
+
+    def fix_citations(self):
+        citations = set()
+        citations.add('''@article{hirata2009multilevel,
+  title={Multilevel training of binary morphological operators},
+  author={Hirata, Nina ST},
+  journal={IEEE Transactions on pattern analysis and machine intelligence},
+  volume={31},
+  number={4},
+  pages={707--720},
+  year={2009},
+  publisher={IEEE}
+}''')
+        for wop in self.wops:
+            cite = wop.cite_me()
+            wop_citations = [s.strip() for s in cite.split('\n\n')]
+            for wop_cit in wop_citations:
+                if wop_cit != '':
+                    citations.add(wop_cit)
+        self.bibtex_citation = '\n\n'.join(citations)
+
 
     def __len__(self):
         if self.bitpack:

--- a/trios/serializable.pyx
+++ b/trios/serializable.pyx
@@ -13,7 +13,6 @@ except ImportError:
 import importlib
 
 def rebuild_serializable(obj_dict):
-    #print(obj_dict, type(obj_dict))
     return Serializable.read(obj_dict)
 
 cdef class Serializable:
@@ -30,6 +29,11 @@ cdef class Serializable:
         obj_dict = {}
         obj_dict['class_name'] = self.__class__.__name__
         obj_dict['class_module'] = self.__class__.__module__
+        
+        try:
+            obj_dict['bibtex_citation'] = self.bibtex_citation
+        except AttributeError:
+            pass
         
         obj_dict['state'] = {}
         self.write_state(obj_dict['state'])
@@ -57,6 +61,10 @@ cdef class Serializable:
         module = importlib.import_module(obj_dict['class_module'])
         class_obj = getattr(module, obj_dict['class_name'])
         obj = class_obj()
+
+        if 'bibtex_citation' in obj_dict:
+            obj.bibtex_citation = obj_dict['bibtex_citation']
+
         obj.set_state(obj_dict['state'])
         
         return obj

--- a/trios/serializable.pyx
+++ b/trios/serializable.pyx
@@ -63,7 +63,10 @@ cdef class Serializable:
         obj = class_obj()
 
         if 'bibtex_citation' in obj_dict:
-            obj.bibtex_citation = obj_dict['bibtex_citation']
+            try:
+                obj.bibtex_citation = obj_dict['bibtex_citation']
+            except AttributeError:
+                pass
 
         obj.set_state(obj_dict['state'])
         

--- a/trios/woperator.py
+++ b/trios/woperator.py
@@ -68,16 +68,14 @@ class WOperator(Serializable):
     (ii) the classifier used (defined in the Classifier class).
     '''
     
-    bibtex_citation = '''
-@inproceedings{montagner2016image,
+    bibtex_citation = '''@inproceedings{montagner2016image,
   title={Image operator learning and applications},
   author={Montagner, Igor S and Hirata, Nina ST and Hirata, Roberto},
   booktitle={Graphics, Patterns and Images Tutorials (SIBGRAPI-T), SIBGRAPI Conference on},
   pages={38--50},
   year={2016},
   organization={IEEE}
-}
-'''
+}'''
 
     
     def cite_me(self):

--- a/trios/woperator.py
+++ b/trios/woperator.py
@@ -67,6 +67,23 @@ class WOperator(Serializable):
     (i) its neighborhood (Window) of the operator;
     (ii) the classifier used (defined in the Classifier class).
     '''
+    
+    bibtex_citation = '''
+@inproceedings{montagner2016image,
+  title={Image operator learning and applications},
+  author={Montagner, Igor S and Hirata, Nina ST and Hirata, Roberto},
+  booktitle={Graphics, Patterns and Images Tutorials (SIBGRAPI-T), SIBGRAPI Conference on},
+  pages={38--50},
+  year={2016},
+  organization={IEEE}
+}
+'''
+
+    
+    def cite_me(self):
+        return '\n'.join([self.bibtex_citation, self.extractor.bibtex_citation,
+                         self.classifier.bibtex_citation])
+    
     def __init__(self, window=None, cls=None, fext=None, batch=True):
         self.window = window
         if inspect.isclass(cls):


### PR DESCRIPTION
I added a method cite_me() to WOperator to list the references used by a WOperator. I think most implemented methods are correctly cited. I added citations for NILC, KA, Two-level, Aperture and the tutorial. 

Please review and approve the pull request. 